### PR TITLE
Added Deploy-webpagetest parameters for the domain input and the passwor...

### DIFF
--- a/heat/webpagetest-private-single.yaml
+++ b/heat/webpagetest-private-single.yaml
@@ -527,7 +527,7 @@ resources:
             }
             #endregion
             #region MAIN : Deploy Web Pagge Test
-            Deploy-WebPagetest
+            Deploy-WebPagetest -DomainName "%wptdomain%" -wpt_user "%wptusername%" -wpt_password "%wptpassword%"
             #endregion
           params:
             "%wptdomain%" : { get_param: domain }


### PR DESCRIPTION
Input parameters are required to secure each deployment with a unique wpt password and allow the input domain to work and the wpt user to be set.
